### PR TITLE
Allow any kind of pod prefix

### DIFF
--- a/main.js
+++ b/main.js
@@ -21,11 +21,11 @@ const groups = [
 })
 
 const types = [
-  { module: 'pod-component', exp: /^(app|addon)\/components\/(.+)\/component\.(js)$/ },
-  { module: 'pod-component-template', exp: /^(app|addon)\/components\/(.+)\/template\.(hbs)$/ },
-  { module: 'pod-component-style', exp: /^(app|addon)\/components\/(.+)\/style\.(css|sass|scss)$/ },
-  { module: 'pod-component-unit', exp: /^()tests\/unit\/components\/(.+)\/component-test\.(js)$/ },
-  { module: 'pod-component-integration', exp: /^()tests\/integration\/components\/(.+)\/component-test\.(js)$/ },
+  { module: 'pod-component', exp: /^(app|addon)\/?(.*)\/components\/(.+)\/component\.(js)$/ },
+  { module: 'pod-component-template', exp: /^(app|addon)\/?(.*)\/components\/(.+)\/template\.(hbs)$/ },
+  { module: 'pod-component-style', exp: /^(app|addon)\/?(.*)\/components\/(.+)\/style\.(css|sass|scss)$/ },
+  { module: 'pod-component-unit', exp: /^()tests\/unit\/?(.*)\/components\/(.+)\/component-test\.(js)$/ },
+  { module: 'pod-component-integration', exp: /^()tests\/integration\/?(.*)\/components\/(.+)\/component-test\.(js)$/ },
   { module: 'component', exp: /^(app|addon|lib\/(?:.+)\/addon)\/components\/(.+)\.(js|ts)$/ },
   { module: 'component-template', exp: /^(app|addon|lib\/(?:.+)\/addon)\/templates\/components\/(.+)\.(hbs)$/ },
   { module: 'component-style', exp: /^(app|addon|lib\/(?:.+)\/addon)\/styles\/components\/(.+)\.(css|sass|scss)$/ },


### PR DESCRIPTION
Fix for #7 

Matches both "app/components/super-component/component.js" and "app/mypods/components/super-component/component.js"